### PR TITLE
Fix copy and paste error

### DIFF
--- a/bin/surfboard
+++ b/bin/surfboard
@@ -87,7 +87,7 @@ if __name__ == '__main__':
             sample_rate=args.fs, num_proc=args.num_proc,
         )
         output_dataframe["fnames"] = files_list
-        output_dataframe.to_pickle(args.output_file, index=False)
+        output_dataframe.to_pickle(args.output_file)
 
 
     else:


### PR DESCRIPTION
'to_pickle' does not support the 'index' parameter