### PR TITLE
🐛 use false dual for tutorial1 linearSVC

### DIFF
--- a/notebook_tutorials/Tutorial1-AudioClassification.ipynb
+++ b/notebook_tutorials/Tutorial1-AudioClassification.ipynb
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "svm = LinearSVC()\n",
+    "svm = LinearSVC(dual=False)\n",
     "\n",
     "# Train the SVM.\n",
     "svm.fit(X_train, label_train)\n",


### PR DESCRIPTION
Hi,

Without dual=False, the algorithm raises
```py
/usr/local/lib/python3.7/site-packages/sklearn/svm/_base.py:977: ConvergenceWarning: Liblinear failed to converge, increase the number of iterations.
  "the number of iterations.", ConvergenceWarning)
```

https://scikit-learn.org/stable/modules/generated/sklearn.svm.LinearSVC.html,
suggests preferring false when n_samples > n_features.

Having changed and re-run the cell, no warning is raised, and the accuracy seems to be increased.

Apologies if this it not actually desired at all :)
