### PR TITLE
Replace positional argument with keyword arg in spectrograms

### DIFF
--- a/surfboard/misc_components.py
+++ b/surfboard/misc_components.py
@@ -302,7 +302,7 @@ def get_bark_spectrogram(waveform, sample_rate, n_fft_seconds, hop_length_second
     hop_length = numseconds_to_numsamples(hop_length_seconds, sample_rate)
 
     # [n_frequency_bins, t]
-    spectrogram, _ = librosa.core.spectrum._spectrogram(waveform, n_fft=n_fft, hop_length=hop_length)
+    spectrogram, _ = librosa.core.spectrum._spectrogram(y=waveform, n_fft=n_fft, hop_length=hop_length)
     frequencies = librosa.core.fft_frequencies(sr=sample_rate, n_fft=n_fft)
 
     assert spectrogram.shape[0] == frequencies.shape[0], "Different number of frequencies..."

--- a/surfboard/sound.py
+++ b/surfboard/sound.py
@@ -154,7 +154,7 @@ class Waveform:
         hop_length = numseconds_to_numsamples(hop_length_seconds, self.sample_rate)
 
         melspec = librosa.feature.melspectrogram(
-            self.waveform, sr=self.sample_rate, n_mels=n_mels, n_fft=n_fft, hop_length=hop_length,
+            y=self.waveform, sr=self.sample_rate, n_mels=n_mels, n_fft=n_fft, hop_length=hop_length,
         )
         return librosa.power_to_db(melspec, ref=np.max)
 
@@ -171,7 +171,7 @@ class Waveform:
         n_fft = numseconds_to_numsamples(n_fft_seconds, self.sample_rate)
         hop_length = numseconds_to_numsamples(hop_length_seconds, self.sample_rate)
 
-        mag_spectrum, _ = librosa.core.spectrum._spectrogram(self.waveform, n_fft=n_fft, hop_length=hop_length)
+        mag_spectrum, _ = librosa.core.spectrum._spectrogram(y=self.waveform, n_fft=n_fft, hop_length=hop_length)
         return mag_spectrum
 
     def bark_spectrogram(self, n_fft_seconds=0.04, hop_length_seconds=0.01):


### PR DESCRIPTION
Librosa is doing away with positional arguments.

Perhaps because of this, magnitude_spectrum and bark_spectrogram produced empty outputs. Log_melspec produced a FutureWarning about the issue.

Fix: Change Librosa spectrogram calls to say 'y=' for the first argument
(in files sound.py and misc_components.py)

Note: I have only worked on magnitude_spectrum, bark_spectrogram and log_melspec. I don't know what else might need to change.

Code to reproduce the issues:
```
import sys
sys.path.insert(0, '/Users/rogierlandman/Documents/GitHub/surfboard/')
from surfboard.sound import Waveform
from surfboard.feature_extraction import extract_features
import matplotlib.pyplot as plt
import librosa
import librosa.display

sound = Waveform(path='./audio_files_jackhammer.wav')
result = extract_features([sound], ['log_melspec'])
log_melspec_array = result['log_melspec'][0]

fig, ax = plt.subplots()
img = librosa.display.specshow(log_melspec_array,y_axis='log', x_axis='time', ax=ax)
ax.set_title('Spectrogram')
fig.colorbar(img, ax=ax)

result = extract_features([sound], ['magnitude_spectrum'])
magspec_array = result['magnitude_spectrum'][0]

fig, ax = plt.subplots()
img = librosa.display.specshow(magspec_array,y_axis='log', x_axis='time', ax=ax)
ax.set_title('Spectrogram')
fig.colorbar(img, ax=ax)

result = extract_features([sound], ['bark_spectrogram'])
bark_spectrogram_array = result['bark_spectrogram'][0]

fig, ax = plt.subplots()
img = librosa.display.specshow(bark_spectrogram_array,y_axis='log', x_axis='time', ax=ax)
ax.set_title('Spectrogram')
fig.colorbar(img, ax=ax)


```

FutureWarning from log_melspec:

```
Extracting features...:   0%|                                                                       | 0/1 [00:00<?, ?it/s]/Users/rogierlandman/Documents/GitHub/surfboard/surfboard/sound.py:157: FutureWarning: Pass y=[-0.00234985 -0.01623535 -0.02853394 ... -0.04025269 -0.02742004
 -0.04121399] as keyword args. From version 0.10 passing these as positional arguments will result in an error
```

Error from magnitude_spectrum:


```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
/var/folders/85/743z8pld6zs5b_lzjt9dd3qm0000gn/T/ipykernel_84251/2046558666.py in <module>
      3 
      4 fig, ax = plt.subplots()
----> 5 img = librosa.display.specshow(magspec_array,y_axis='log', x_axis='time', ax=ax)
      6 ax.set_title('Power spectrogram')
      7 fig.colorbar(img, ax=ax)

~/opt/anaconda3/envs/surfboard_test/lib/python3.7/site-packages/librosa/util/decorators.py in inner_f(*args, **kwargs)
     86             extra_args = len(args) - len(all_args)
     87             if extra_args <= 0:
---> 88                 return f(*args, **kwargs)
     89 
     90             # extra_args > 0

~/opt/anaconda3/envs/surfboard_test/lib/python3.7/site-packages/librosa/display.py in specshow(data, x_coords, y_coords, x_axis, y_axis, sr, hop_length, n_fft, win_length, fmin, fmax, tuning, bins_per_octave, key, Sa, mela, thaat, auto_aspect, htk, unicode, ax, **kwargs)
    851         data = np.abs(data)
    852 
--> 853     kwargs.setdefault("cmap", cmap(data))
    854     kwargs.setdefault("rasterized", True)
    855     kwargs.setdefault("edgecolors", "None")

~/opt/anaconda3/envs/surfboard_test/lib/python3.7/site-packages/librosa/util/decorators.py in inner_f(*args, **kwargs)
     86             extra_args = len(args) - len(all_args)
     87             if extra_args <= 0:
---> 88                 return f(*args, **kwargs)
     89 
     90             # extra_args > 0

~/opt/anaconda3/envs/surfboard_test/lib/python3.7/site-packages/librosa/display.py in cmap(data, robust, cmap_seq, cmap_bool, cmap_div)
    601         min_p, max_p = 0, 100
    602 
--> 603     min_val, max_val = np.percentile(data, [min_p, max_p])
    604 
    605     if min_val >= 0 or max_val <= 0:

<__array_function__ internals> in percentile(*args, **kwargs)

~/opt/anaconda3/envs/surfboard_test/lib/python3.7/site-packages/numpy/lib/function_base.py in percentile(a, q, axis, out, overwrite_input, interpolation, keepdims)
   3866         raise ValueError("Percentiles must be in the range [0, 100]")
   3867     return _quantile_unchecked(
-> 3868         a, q, axis, out, overwrite_input, interpolation, keepdims)
   3869 
   3870 

~/opt/anaconda3/envs/surfboard_test/lib/python3.7/site-packages/numpy/lib/function_base.py in _quantile_unchecked(a, q, axis, out, overwrite_input, interpolation, keepdims)
   3986     r, k = _ureduce(a, func=_quantile_ureduce_func, q=q, axis=axis, out=out,
   3987                     overwrite_input=overwrite_input,
-> 3988                     interpolation=interpolation)
   3989     if keepdims:
   3990         return r.reshape(q.shape + k)

~/opt/anaconda3/envs/surfboard_test/lib/python3.7/site-packages/numpy/lib/function_base.py in _ureduce(a, func, **kwargs)
   3562         keepdim = (1,) * a.ndim
   3563 
-> 3564     r = func(a, **kwargs)
   3565     return r, keepdim
   3566 

~/opt/anaconda3/envs/surfboard_test/lib/python3.7/site-packages/numpy/lib/function_base.py in _quantile_ureduce_func(***failed resolving arguments***)
   4096                 indices_below.ravel(), indices_above.ravel(), [-1]
   4097             )), axis=0)
-> 4098             n = np.isnan(ap[-1])
   4099         else:
   4100             # cannot contain nan

IndexError: index -1 is out of bounds for axis 0 with size 0
```

